### PR TITLE
Installation instructions corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Once all the dependencies are installed, follow the steps below
 * Clone the repo
 * `cp example.travis.yml .travis.yml`
 * `cp example.config.json config.json`
-* Execute ```npm install gulp```
+* Execute ```npm install -g gulp```
 * Execute ```npm install```
 * Execute ```composer install```
 * Move your Drupal codebase to docroot directory


### PR DESCRIPTION
- If you want to run the test locally, it is necessary to install Gulp
  globally, this makes sure sure `gulp` executable is created.